### PR TITLE
fix: Ensure correct rendering of Unicode glyphs in Windows consoles

### DIFF
--- a/ralph.ps1
+++ b/ralph.ps1
@@ -100,6 +100,10 @@ param(
 $ErrorActionPreference = 'Stop'
 $RALPH_VERSION = "1.1.0"
 
+# Ensure Unicode glyphs (e.g., checkmarks) render correctly in Windows consoles.
+[Console]::OutputEncoding = [System.Text.Encoding]::UTF8
+$OutputEncoding = [System.Text.UTF8Encoding]::new()
+
 function Show-Usage {
     @"
 Usage:


### PR DESCRIPTION
This pull request makes a small but important change to the `ralph.ps1` script to improve console output compatibility. The update ensures that Unicode glyphs, such as checkmarks, render correctly in Windows consoles by setting the appropriate output encoding.